### PR TITLE
Add search benchmark

### DIFF
--- a/src/main/java/com/cloudant/fdblucene/benchmark/BasicSearchBenchmark.java
+++ b/src/main/java/com/cloudant/fdblucene/benchmark/BasicSearchBenchmark.java
@@ -1,0 +1,70 @@
+package com.cloudant.fdblucene.benchmark;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class BasicSearchBenchmark {
+
+    @BenchmarkMode(Mode.Throughput)
+    @Fork(1)
+    @Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.MINUTES)
+    @Timeout(time = 5, timeUnit = TimeUnit.MINUTES)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Benchmark
+    @Group("searchFDB")
+    @GroupThreads(1)
+    public void searchFDB(FDBSearchSetup setup) throws Exception {
+        int randomSearchPosition = setup.random.nextInt(setup.searchTermList.size());
+        String term = setup.searchTermList.get(randomSearchPosition);
+        // we don't actually care about the number of hits
+        setup.searcher.search(new TermQuery(new Term("body", term)), setup.topNDocs);
+    }
+
+    @BenchmarkMode(Mode.Throughput)
+    @Fork(1)
+    @Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.MINUTES)
+    @Timeout(time = 5, timeUnit = TimeUnit.MINUTES)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Benchmark
+    @Group("searchNIOS")
+    @GroupThreads(1)
+    public void searchNIOS(NIOSSearchSetup setup) throws Exception {
+        int randomSearchPosition = setup.random.nextInt(setup.searchTermList.size());
+        String term = setup.searchTermList.get(randomSearchPosition);
+        // we don't actually care about the number of hits
+        setup.searcher.search(new TermQuery(new Term("body", term)), setup.topNDocs);
+    }
+
+    public static void main(final String[] args) throws RunnerException {
+        final Options opt = new OptionsBuilder().include(BasicSearchBenchmark.class.getSimpleName()).build();
+        new Runner(opt).run();
+    }
+
+}

--- a/src/main/java/com/cloudant/fdblucene/benchmark/BasicSearchBenchmark.java
+++ b/src/main/java/com/cloudant/fdblucene/benchmark/BasicSearchBenchmark.java
@@ -34,16 +34,16 @@ public class BasicSearchBenchmark {
     @Fork(1)
     @Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
     @Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.MINUTES)
-    @Timeout(time = 5, timeUnit = TimeUnit.MINUTES)
+    @Timeout(time = 15, timeUnit = TimeUnit.MINUTES)
     @OutputTimeUnit(TimeUnit.SECONDS)
     @Benchmark
-    @Group("searchFDB")
-    @GroupThreads(1)
-    public void searchFDB(FDBSearchSetup setup) throws Exception {
+    public long searchFDB(FDBSearchSetup setup) throws Exception {
         int randomSearchPosition = setup.random.nextInt(setup.searchTermList.size());
         String term = setup.searchTermList.get(randomSearchPosition);
         // we don't actually care about the number of hits
-        setup.searcher.search(new TermQuery(new Term("body", term)), setup.topNDocs);
+        TopDocs tp = setup.searcher.search(new TermQuery(new Term("body", term)),
+            setup.topNDocs);
+        return tp.totalHits.value;
     }
 
     @BenchmarkMode(Mode.Throughput)
@@ -53,13 +53,13 @@ public class BasicSearchBenchmark {
     @Timeout(time = 5, timeUnit = TimeUnit.MINUTES)
     @OutputTimeUnit(TimeUnit.SECONDS)
     @Benchmark
-    @Group("searchNIOS")
-    @GroupThreads(1)
-    public void searchNIOS(NIOSSearchSetup setup) throws Exception {
+    public long searchNIOS(NIOSSearchSetup setup) throws Exception {
         int randomSearchPosition = setup.random.nextInt(setup.searchTermList.size());
         String term = setup.searchTermList.get(randomSearchPosition);
         // we don't actually care about the number of hits
-        setup.searcher.search(new TermQuery(new Term("body", term)), setup.topNDocs);
+        TopDocs tp = setup.searcher.search(new TermQuery(new Term("body", term)),
+            setup.topNDocs);
+        return tp.totalHits.value;
     }
 
     public static void main(final String[] args) throws RunnerException {

--- a/src/main/java/com/cloudant/fdblucene/benchmark/FDBSearchSetup.java
+++ b/src/main/java/com/cloudant/fdblucene/benchmark/FDBSearchSetup.java
@@ -1,0 +1,37 @@
+package com.cloudant.fdblucene.benchmark;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.apache.lucene.store.Directory;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.apple.foundationdb.FDB;
+import com.cloudant.fdblucene.FDBDirectory;
+
+public class FDBSearchSetup extends SearchSetup {
+
+    @Setup(Level.Trial)
+    public void startFDBNetworking() throws Exception {
+        FDB.selectAPIVersion(600);
+        db = FDB.instance().open();
+        super.setup();
+    }
+
+    @TearDown(Level.Trial)
+    public void closeFDB() throws Exception {
+        super.cleanDirectory();
+        db.close();
+    }
+
+    @Override
+    public Directory getDirectory(final Path path) throws IOException {
+        return FDBDirectory.open(db, path);
+    }
+}
+
+
+

--- a/src/main/java/com/cloudant/fdblucene/benchmark/NIOSSearchSetup.java
+++ b/src/main/java/com/cloudant/fdblucene/benchmark/NIOSSearchSetup.java
@@ -1,0 +1,27 @@
+package com.cloudant.fdblucene.benchmark;
+
+import java.io.IOException;
+
+import java.nio.file.Path;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.NIOFSDirectory;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Setup;
+
+
+public class NIOSSearchSetup extends SearchSetup {
+
+    @Setup(Level.Trial)
+    public void setupNIOS() throws Exception{
+        super.setup();
+    }
+
+    @Override
+    public Directory getDirectory(final Path path) throws IOException {
+        return new NIOFSDirectory(path);
+    }
+
+}
+

--- a/src/main/java/com/cloudant/fdblucene/benchmark/SearchSetup.java
+++ b/src/main/java/com/cloudant/fdblucene/benchmark/SearchSetup.java
@@ -1,0 +1,116 @@
+package com.cloudant.fdblucene.benchmark;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.apache.lucene.codecs.lucene80.Lucene80Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.LineFileDocs;
+import org.apache.lucene.util.LuceneTestCase;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.apple.foundationdb.Database;
+
+@State(Scope.Benchmark)
+public abstract class SearchSetup {
+    public Database db;
+    public Directory dir;
+    public Document doc;
+    public IndexWriter writer;
+    public DirectoryReader reader;
+    public IndexSearcher searcher;
+    public StringField idField;
+    public AtomicLong counter = new AtomicLong();
+    public Random random;
+    public LineFileDocs docs;
+    public int docsToIndex = 100;
+    public List<String> searchTermList = new ArrayList<String>();
+    public int topNDocs = 50;
+    public int maxSearchTerms = 10;
+
+    public abstract Directory getDirectory(final Path path) throws IOException;
+
+    public void setup() throws Exception {
+        final IndexWriterConfig config = indexWriterConfig();
+        dir = getDirectory(generateTestPath());
+        cleanDirectory();
+        writer = new IndexWriter(dir, config);
+        random = new Random();
+        for (int i = 0; i < docsToIndex; i++) {
+            docs = new LineFileDocs(random, LuceneTestCase.DEFAULT_LINE_DOCS_FILE);
+            doc = docs.nextDoc();
+            // Look through the body's terms, grab a String term, store it
+            // so that it can be randomly chosen for search later on
+            String[] body = doc.getValues("body");
+            String[] terms = null;
+            if(body.length > 0) {
+                terms = body[0].split("\\s+");
+            }
+            if(terms !=null && searchTermList.size() < maxSearchTerms) {
+                int randomTermPosition = random.nextInt(terms.length);
+                searchTermList.add(terms[randomTermPosition]);
+            }
+
+            idField = new StringField("_id", "", Store.YES);
+            idField.setStringValue("doc-" + counter.incrementAndGet());
+            doc.add(idField);
+            writer.addDocument(doc);
+        }
+        writer.commit();
+        System.out.println("Commited Indexing");
+        writer.close();
+    }
+
+    @Setup(Level.Iteration)
+    public void createReader() throws Exception {
+        reader = DirectoryReader.open(dir);
+        searcher = new IndexSearcher(reader);
+    }
+
+    @TearDown(Level.Iteration)
+    public void teardown() throws Exception {
+        reader.close();
+    }
+
+    protected void cleanDirectory() throws IOException {
+        for (final String name : dir.listAll()) {
+            dir.deleteFile(name);
+        }
+    }
+
+    protected Path generateTestPath() {
+        final String dir = System.getProperty("dir");
+        if (dir == null){
+            throw new Error("System property 'dir' not set.");
+        }
+        final FileSystem fileSystem = FileSystems.getDefault();
+        return fileSystem.getPath(dir);
+    }
+
+    protected IndexWriterConfig indexWriterConfig() {
+        final IndexWriterConfig config = new IndexWriterConfig();
+        config.setUseCompoundFile(false);
+        config.setCodec(new Lucene80Codec());
+        return config;
+    }
+}

--- a/src/main/java/com/cloudant/fdblucene/benchmark/SearchSetup.java
+++ b/src/main/java/com/cloudant/fdblucene/benchmark/SearchSetup.java
@@ -43,10 +43,10 @@ public abstract class SearchSetup {
     public AtomicLong counter = new AtomicLong();
     public Random random;
     public LineFileDocs docs;
-    public int docsToIndex = 100;
+    public int docsToIndex = 100000;
     public List<String> searchTermList = new ArrayList<String>();
     public int topNDocs = 50;
-    public int maxSearchTerms = 10;
+    public int maxSearchTerms = 1000;
 
     public abstract Directory getDirectory(final Path path) throws IOException;
 


### PR DESCRIPTION
We separate the search benchmark into their own classes.

1) SearchSetup - Indexes 100k documents and creates a random array of search terms based on terms found in those 100k documents

2) FDBSearchSetup - Indexes 100k docs into FDB

3) NIOSSearchSetup - Indexes 100k docs into NIOSFileDirectory

4) BasicSearchBenchmark - Two search functions that is used for the benchmark. One takes in FDBSearchSetup as the state class parameter, and the other takes in NIOSSearchSetup

This acts as the foundation for the search benchmark. 